### PR TITLE
CORE-1211: update the type field in outgoing AMQP notifications

### DIFF
--- a/handlers/legacy.go
+++ b/handlers/legacy.go
@@ -151,7 +151,7 @@ func (lh *Legacy) buildNotificationMessage(
 		Payload:       payload,
 		Seen:          request.Seen,
 		Subject:       request.Subject,
-		Type:          request.NotificationType,
+		Type:          strings.ReplaceAll(request.NotificationType, "_", " "),
 		User:          request.User,
 	}
 


### PR DESCRIPTION
This PR replaces underscores with hyphens in the `type` field of outgoing notifications being published to AMQP. We also have to convert the integer fields, `total` and `unseen_total` to strings. That will be done in a subsequent PR.